### PR TITLE
fix for "Answer Buttons incorrect number" and "language warnings"

### DIFF
--- a/src/five_finger_silver/fixReLrnStats.py
+++ b/src/five_finger_silver/fixReLrnStats.py
@@ -11,12 +11,12 @@ from anki.stats import *
 from anki.hooks import wrap
 
 
-TYPES = {0: [0, 0], 1: [0, 0], 2: [0,0], 3: [0, 0]}
 
 
 # From: anki.stats.CollectionStats
 # Mod: added range and type 3
 def _easeInfo(self, eases, _old):
+    TYPES = {0: [0, 0], 1: [0, 0], 2: [0,0], 3: [0, 0]}
     for (type, ease, cnt) in eases:
         if ease == 1:
             TYPES[type][0] += cnt

--- a/src/five_finger_silver/fixReLrnStats.py
+++ b/src/five_finger_silver/fixReLrnStats.py
@@ -9,7 +9,7 @@
 
 from anki.stats import *
 from anki.hooks import wrap
-
+from anki.lang import _
 
 
 

--- a/src/five_finger_silver/fixReMemorize.py
+++ b/src/five_finger_silver/fixReMemorize.py
@@ -9,6 +9,7 @@
 
 from anki.stats import *
 from anki.hooks import wrap
+from anki.lang import _
 
 
 TYPES=("lrn", "yng", "mtr", 'rel')


### PR DESCRIPTION
just opening and closing the stats window multiple times increases the numbers below  "Answer Buttons - The number of times you have pressed each button" if you view the stats for the deck (as does switching between "deck" and "collection").

The other commit is about removing the warning  `accessing _ without importing from anki.lang will break in the future` on the commandline which makes my print debugging harder.